### PR TITLE
chore: use `renv::install` to install R deps

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		"ghcr.io/devcontainers/features/rust:1": {
 			"version": "latest"
 		},
+		"ghcr.io/rocker-org/devcontainer-features/renv-cache": {},
 		"ghcr.io/eitsupi/devcontainer-features/go-task": {}
 	},
 	"customizations": {

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,8 +21,10 @@ tasks:
     desc: Install R packages for development.
     cmds:
       - Rscript -e
-        'pak::repo_add(extendr = "https://extendr.r-universe.dev");
-        pak::local_install_deps(dependencies = c("all", "Config/Needs/dev", "Config/Needs/website"))'
+        'renv::install(
+          dependencies = c("config/needs/dev", "config/needs/website"),
+          repos = c(getOption("repos"), extendr = "https://extendr.r-universe.dev")
+        )'
 
   install-rust-tools:
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,7 +22,7 @@ tasks:
     cmds:
       - Rscript -e
         'renv::install(
-          dependencies = c("config/needs/dev", "config/needs/website"),
+          dependencies = c("Imports", "Depends", "LinkingTo", "Config/Needs/dev", "Config/Needs/website"),
           repos = c(getOption("repos"), extendr = "https://extendr.r-universe.dev")
         )'
 


### PR DESCRIPTION
It does not seem to work with errors now.