### PR TITLE
Clean up the intermediate objects to avoid warning

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -8,7 +8,7 @@ LIBDIR = $(TARGET_DIR)/$(TARGET)/$(PRQLR_PROFILE)
 STATLIB = $(LIBDIR)/$(LIBNAME)
 PKG_LIBS = -L$(LIBDIR) -lprqlr
 
-all: C_clean
+all: $(SHLIB) clean_intermediate
 
 $(SHLIB): $(STATLIB)
 
@@ -47,8 +47,10 @@ $(STATLIB):
 		rm -Rf "$(CARGOTMP)" "$(VENDOR_DIR)" "$(LIBDIR)/build"; \
 	fi
 
-C_clean:
-	rm -Rf "$(SHLIB)" "$(STATLIB)" "$(OBJECTS)"
+clean_intermediate:
+	rm -f "$(STATLIB)"
 
 clean:
 	rm -Rf "$(SHLIB)" "$(STATLIB)" "$(OBJECTS)" "$(TARGET_DIR)"
+
+.PHONY: all clean_intermediate clean

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -12,7 +12,7 @@ PKG_LIBS = -L$(LIBDIR) -lprqlr -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 # need to overwrite it via configuration.
 CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
 
-all: C_clean
+all: $(SHLIB) clean_intermediate
 
 $(SHLIB): $(STATLIB)
 
@@ -53,8 +53,10 @@ $(STATLIB):
 		rm -Rf "$(CARGOTMP)" "$(VENDOR_DIR)" "$(LIBDIR)/build"; \
 	fi
 
-C_clean:
-	rm -Rf "$(SHLIB)" "$(STATLIB)" "$(OBJECTS)" "$(LIBGCC_MOCK_DIR)"
+clean_intermediate:
+	rm -Rf "$(SHLIB)" "$(LIBGCC_MOCK_DIR)"
 
 clean:
 	rm -Rf "$(SHLIB)" "$(STATLIB)" "$(OBJECTS)" "$(TARGET_DIR)" "$(LIBGCC_MOCK_DIR)"
+
+.PHONY: all clean_intermediate clean


### PR DESCRIPTION
From some days ago, `R CMD check` checks the compiled code in the sub-directories and it gives this warning. I believe this is false positive. `rust/target/.../release/libprqlr.a` is not necessary after generating `SHLIB`. However, with the current `Makevars.*`, it doesn't get cleaned up at the time of the check.

This pull request moves the clean up earlier by making it the subsequent step to `$(SHLIB)`.

https://cran.r-project.org/web/checks/check_results_prqlr.html

```
  File ‘prqlr/libs/prqlr.so’:
    Found ‘_exit’, possibly from ‘_exit’ (C)
      Object: ‘rust/target/x86_64-unknown-linux-gnu/release/libprqlr.a’
    Found ‘abort’, possibly from ‘abort’ (C)
      Object: ‘rust/target/x86_64-unknown-linux-gnu/release/libprqlr.a’
    Found ‘exit’, possibly from ‘exit’ (C)
      Object: ‘rust/target/x86_64-unknown-linux-gnu/release/libprqlr.a’
  
  Compiled code should not call entry points which might terminate R nor
  write to stdout/stderr instead of to the console, nor use Fortran I/O
  nor system RNGs nor [v]sprintf.
  
  See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual
```

More details can be found:

- https://github.com/yutannihilation/savvy/issues/355
- https://github.com/yutannihilation/savvy/pull/357