### PR TITLE
fix: ensure cleanup after the lib build

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -9,7 +9,7 @@ STATLIB = $(LIBDIR)/$(LIBNAME)
 PKG_LIBS = -L$(LIBDIR) -lprqlr
 
 .PHONY: all
-all: C_clean $(SHLIB) cleanup
+all: $(SHLIB) cleanup
 
 $(SHLIB): $(STATLIB)
 
@@ -44,16 +44,13 @@ $(STATLIB):
 	    --profile="$(PRQLR_PROFILE)" --features="$(PRQLR_FEATURES)" -Zbuild-std=panic_abort,std; \
 	fi
 
-.PHONY: C_clean
-C_clean:
-	rm -Rf "$(SHLIB)" "$(STATLIB)" "$(OBJECTS)"
-
 .PHONY: cleanup
-cleanup:
+# Clean up files that may cause warnings in R CMD check on CRAN just after the build
+cleanup: $(SHLIB)
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf "$(STATLIB)" "$(CARGOTMP)" "$(VENDOR_DIR)" "$(LIBDIR)/build"; \
 	fi
 
 .PHONY: clean
-clean: C_clean
-	rm -Rf "$(TARGET_DIR)"
+clean:
+	rm -Rf "$(SHLIB)" "$(STATLIB)" "$(OBJECTS)" "$(TARGET_DIR)"

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -13,7 +13,7 @@ PKG_LIBS = -L$(LIBDIR) -lprqlr -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
 
 .PHONY: all
-all: C_clean $(SHLIB) cleanup
+all: $(SHLIB) cleanup
 
 $(SHLIB): $(STATLIB)
 
@@ -50,16 +50,13 @@ $(STATLIB):
 		cargo build --lib --manifest-path="$(CURDIR)/rust/Cargo.toml" --target-dir "$(TARGET_DIR)" --target="$(TARGET)" \
 			--profile="$(PRQLR_PROFILE)" --features="$(PRQLR_FEATURES)"
 
-.PHONY: C_clean
-C_clean:
-	rm -Rf "$(SHLIB)" "$(STATLIB)" "$(OBJECTS)" "$(LIBGCC_MOCK_DIR)"
-
 .PHONY: cleanup
-cleanup:
+# Clean up files that may cause warnings in R CMD check on CRAN just after the build
+cleanup: $(SHLIB)
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf "$(STATLIB)" "$(CARGOTMP)" "$(VENDOR_DIR)" "$(LIBDIR)/build"; \
 	fi
 
 .PHONY: clean
-clean: C_clean
-	rm -Rf "$(TARGET_DIR)"
+clean:
+	rm -Rf "$(SHLIB)" "$(STATLIB)" "$(OBJECTS)" "$(LIBGCC_MOCK_DIR)" "$(TARGET_DIR)"


### PR DESCRIPTION
Pointed out by https://github.com/yutannihilation/savvy/issues/355#issuecomment-2740111502

And, deletes the `C_clean` target that are deemed unnecessary.